### PR TITLE
Fix div by zero on local variables retyping

### DIFF
--- a/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/VariableUtilities.java
+++ b/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/listing/VariableUtilities.java
@@ -561,7 +561,7 @@ public class VariableUtilities {
 			callingConvention = compilerSpec.getDefaultCallingConvention();
 		}
 		int stackAlign = callingConvention.getStackParameterAlignment();
-		if (stackAlign < 0) {
+		if (stackAlign <= 0) {
 			stackAlign = 1;
 		}
 		int bias = 0;


### PR DESCRIPTION
Div by zero occured if changing local variable type to greater size type in decompiler.